### PR TITLE
feat: add writer type using deref and demut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+mod writer;
+mod types;
+
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,4 @@
+use sqlx::{Pool, Postgres};
+
+pub struct Reader(Pool<Postgres>);
+pub struct Writer(Pool<Postgres>);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,17 @@
+use std::ops::{Deref, DerefMut};
+use sqlx::{Pool, Postgres};
+use crate::types::Writer;
+
+impl Deref for Writer {
+    type Target = Pool<Postgres>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Writer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}


### PR DESCRIPTION
Following this approach, using defer and default to keep compatibility between the writer type and pgpool type.

This way, we can guarantee all of these benefits:

Transparency: Allows Reader and Writer to be used as PgPool without modifying the code that expects a PgPool.

Encapsulation: The reader and writer structures can still be enhanced by adding methods or additional logic in the future.

Flexibility: We can control which methods or properties to expose by implementing or not certain traits.
